### PR TITLE
Implement player authentication

### DIFF
--- a/assets/shaders/Logo.nzsl
+++ b/assets/shaders/Logo.nzsl
@@ -1,0 +1,152 @@
+[nzsl_version("1.0")]
+module TSOM.Logo;
+
+import InstanceData from Engine.InstanceData;
+import ViewerData from Engine.ViewerData;
+
+// Material options
+option HasBaseColorTexture: bool = false;
+option HasAlphaTexture: bool = false;
+option AlphaTest: bool = false;
+
+// Vertex declaration related options
+option VertexColorLoc: i32 = -1;
+option VertexNormalLoc: i32 = -1;
+option VertexPositionLoc: i32 = -1;
+option VertexSizeRotLocation: i32 = -1;
+option VertexUvLoc: i32 = -1;
+
+option VertexJointIndicesLoc: i32 = -1;
+option VertexJointWeightsLoc: i32 = -1;
+
+const HasNormal = (VertexNormalLoc >= 0);
+const HasVertexColor = (VertexColorLoc >= 0);
+const HasColor = (HasVertexColor);
+const HasVertexUV = (VertexUvLoc >= 0);
+const HasUV = (HasVertexUV);
+const HasSkinning = (VertexJointIndicesLoc >= 0 && VertexJointWeightsLoc >= 0);
+
+[layout(std140)]
+struct MaterialSettings
+{
+	[tag("AlphaTestThreshold")]
+	AlphaThreshold: f32,
+
+	[tag("ShadowMapNormalOffset")]
+	ShadowMapNormalOffset: f32,
+
+	[tag("ShadowPosScale")]
+	ShadowPosScale: f32,
+
+	[tag("BaseColor")]
+	BaseColor: vec4[f32]
+}
+
+[tag("Material")]
+[auto_binding]
+external
+{
+	[tag("Settings")] settings: uniform[MaterialSettings],
+	[tag("BaseColorMap")] MaterialBaseColorMap: sampler2D[f32],
+	[tag("AlphaMap")] MaterialAlphaMap: sampler2D[f32],
+}
+
+[tag("Engine")]
+[auto_binding]
+external
+{
+	[tag("TextureOverlay")] TextureOverlay: sampler2D[f32],
+	[tag("InstanceData")] instanceData: uniform[InstanceData],
+	[tag("ViewerData")] viewerData: uniform[ViewerData],
+}
+
+struct VertOut
+{
+	[location(0)] worldPos: vec3[f32],
+	[location(1), cond(HasUV)] uv: vec2[f32],
+	[location(2), cond(HasColor)] color: vec4[f32],
+	[builtin(position)] position: vec4[f32]
+}
+
+// Fragment stage
+struct FragOut
+{
+	[location(0)] RenderTarget0: vec4[f32],
+}
+
+fn ComputeColor(input: VertOut) -> vec4[f32]
+{
+	let color = settings.BaseColor;
+
+	const if (HasUV)
+		color.a *= TextureOverlay.Sample(input.uv).r;
+
+	const if (HasColor)
+		color *= input.color;
+
+	const if (HasBaseColorTexture)
+		color *= MaterialBaseColorMap.Sample(input.uv);
+
+	const if (HasAlphaTexture)
+		color.w *= MaterialAlphaMap.Sample(input.uv).x;
+
+	const if (AlphaTest)
+	{
+		if (color.w < settings.AlphaThreshold)
+			discard;
+	}
+
+	return color;
+}
+
+[entry(frag)]
+fn FragMain(input: VertOut) -> FragOut
+{
+	let color = ComputeColor(input);
+
+	let output: FragOut;
+	output.RenderTarget0 = color;
+	return output;
+}
+
+// Vertex stage
+struct VertIn
+{
+	[location(VertexPositionLoc)]
+	pos: vec3[f32],
+
+	[cond(HasVertexColor), location(VertexColorLoc)]
+	color: vec4[f32],
+
+	[cond(HasNormal), location(VertexNormalLoc)]
+	normal: vec3[f32],
+
+	[cond(HasVertexUV), location(VertexUvLoc)]
+	uv: vec2[f32],
+
+	[cond(HasSkinning), location(VertexJointIndicesLoc)]
+	jointIndices: vec4[i32],
+
+	[cond(HasSkinning), location(VertexJointWeightsLoc)]
+	jointWeights: vec4[f32]
+}
+
+[entry(vert)]
+fn VertMain(input: VertIn) -> VertOut
+{
+	let pos = input.pos;
+
+	let worldPosition = instanceData.worldMatrix * vec4[f32](pos, 1.0);
+
+	let output: VertOut;
+	output.worldPos = worldPosition.xyz;
+	output.position = viewerData.viewProjMatrix * worldPosition;
+
+	const if (HasColor)
+		output.color = input.color;
+
+	const if (HasVertexUV)
+		output.uv = input.uv;
+
+	return output;
+}

--- a/gameconfig.lua.default
+++ b/gameconfig.lua.default
@@ -1,3 +1,6 @@
+Api = {
+	Url = "https://tsom-api.digitalpulse.software"
+}
 Server = {
 	Port = 29536,
 }

--- a/include/CommonLib/Protocol/ConnectionToken.hpp
+++ b/include/CommonLib/Protocol/ConnectionToken.hpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#pragma once
+
+#ifndef TSOM_COMMONLIB_PROTOCOL_CONNECTIONTOKEN_HPP
+#define TSOM_COMMONLIB_PROTOCOL_CONNECTIONTOKEN_HPP
+
+#include <Nazara/Network/IpAddress.hpp>
+#include <NazaraUtils/Prerequisites.hpp>
+#include <CommonLib/Protocol/PacketSerializer.hpp>
+#include <array>
+#include <span>
+#include <string>
+
+namespace tsom
+{
+	enum class ConnectionTokenAuth
+	{
+		CorruptToken,
+		ForgedToken,
+		Success
+		// TODO: Add timestamp check
+	};
+
+	struct ConnectionToken
+	{
+		Nz::UInt32 tokenVersion;
+		std::array<Nz::UInt8, 12> tokenNonce;
+
+		Nz::UInt64 creationTimestamp;
+		Nz::UInt64 expireTimestamp;
+
+		struct
+		{
+			std::array<Nz::UInt8, 32> keyClientToServer;
+			std::array<Nz::UInt8, 32> keyServerToClient;
+		} encryption;
+
+		struct
+		{
+			std::string address;
+			Nz::UInt64 port;
+		} gameServer;
+
+		std::vector<Nz::UInt8> privateToken;
+
+		static constexpr Nz::UInt8 CurrentTokenVersion = 1;
+		static constexpr std::size_t TokenPrivateMaxSize = 2048;
+	};
+
+	struct ConnectionTokenPrivate
+	{
+		// Encryption confirmation
+		struct
+		{
+			std::array<Nz::UInt8, 32> keyClientToServer;
+			std::array<Nz::UInt8, 32> keyServerToClient;
+		} encryption;
+
+		// API part
+		struct
+		{
+			std::string token;
+			std::string url;
+		} api;
+
+		// Player info
+		struct
+		{
+			std::string guid;
+			std::string nickname;
+		} player;
+
+		static ConnectionTokenAuth AuthAndDecrypt(std::span<const Nz::UInt8> tokenData, Nz::UInt32 tokenVersion, Nz::UInt64 expireTimestamp, std::span<const Nz::UInt8, 12> nonce, std::span<const Nz::UInt8, 32> key, ConnectionTokenPrivate* token);
+	};
+
+	namespace Packets
+	{
+		TSOM_COMMONLIB_API void Serialize(PacketSerializer& serializer, ConnectionToken& token);
+		TSOM_COMMONLIB_API void Serialize(PacketSerializer& serializer, ConnectionTokenPrivate& token);
+	}
+}
+
+#include <CommonLib/Protocol/ConnectionToken.inl>
+
+#endif // TSOM_COMMONLIB_PROTOCOL_CONNECTIONTOKEN_HPP

--- a/include/CommonLib/Protocol/ConnectionToken.inl
+++ b/include/CommonLib/Protocol/ConnectionToken.inl
@@ -1,0 +1,9 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#include <CommonLib/Protocol/ConnectionToken.hpp>
+
+namespace tsom
+{
+}

--- a/include/CommonLib/Protocol/Packets.hpp
+++ b/include/CommonLib/Protocol/Packets.hpp
@@ -43,6 +43,7 @@ namespace tsom
 
 	enum class AuthError : Nz::UInt8
 	{
+		InvalidToken = 3,
 		ProtocolError = 2,
 		ServerIsOutdated = 0,
 		UpgradeRequired = 1,

--- a/include/CommonLib/Protocol/Packets.hpp
+++ b/include/CommonLib/Protocol/Packets.hpp
@@ -13,6 +13,7 @@
 #include <CommonLib/PlayerIndex.hpp>
 #include <CommonLib/PlayerInputs.hpp>
 #include <CommonLib/Protocol/CompressedInteger.hpp>
+#include <CommonLib/Protocol/ConnectionToken.hpp>
 #include <CommonLib/Protocol/PacketSerializer.hpp>
 #include <CommonLib/Protocol/SecuredString.hpp>
 #include <Nazara/Math/Quaternion.hpp>
@@ -83,7 +84,18 @@ namespace tsom
 		struct AuthRequest
 		{
 			Nz::UInt32 gameVersion;
-			SecuredString<Constants::PlayerMaxNicknameLength> nickname;
+
+			struct AuthenticatedPlayerData
+			{
+				ConnectionToken connectionToken;
+			};
+
+			struct AnonymousPlayerData
+			{
+				SecuredString<Constants::PlayerMaxNicknameLength> nickname;
+			};
+
+			std::variant<AuthenticatedPlayerData, AnonymousPlayerData> token;
 		};
 
 		struct AuthResponse

--- a/include/CommonLib/Protocol/SecuredString.hpp
+++ b/include/CommonLib/Protocol/SecuredString.hpp
@@ -32,6 +32,10 @@ namespace tsom
 			SecuredString(const SecuredString&) = default;
 			SecuredString(SecuredString&&) noexcept = default;
 
+			std::string& Str() &;
+			const std::string& Str() const&;
+			std::string&& Str() &&;
+
 			SecuredString& operator=(std::string_view str);
 			SecuredString& operator=(const SecuredString&) = default;
 			SecuredString& operator=(SecuredString&&) noexcept = default;

--- a/include/CommonLib/Protocol/SecuredString.inl
+++ b/include/CommonLib/Protocol/SecuredString.inl
@@ -27,6 +27,24 @@ namespace tsom
 	}
 
 	template<std::size_t N, bool CodepointLimit>
+	std::string& SecuredString<N, CodepointLimit>::Str() &
+	{
+		return m_str;
+	}
+
+	template<std::size_t N, bool CodepointLimit>
+	const std::string& SecuredString<N, CodepointLimit>::Str() const&
+	{
+		return m_str;
+	}
+
+	template<std::size_t N, bool CodepointLimit>
+	std::string&& SecuredString<N, CodepointLimit>::Str() &&
+	{
+		return std::move(m_str);
+	}
+
+	template<std::size_t N, bool CodepointLimit>
 	SecuredString<N, CodepointLimit>::operator std::string& () &
 	{
 		return m_str;

--- a/include/CommonLib/UpdaterAppComponent.hpp
+++ b/include/CommonLib/UpdaterAppComponent.hpp
@@ -18,10 +18,12 @@
 
 namespace tsom
 {
+	class ConfigFile;
+
 	class TSOM_COMMONLIB_API UpdaterAppComponent final : public Nz::ApplicationComponent
 	{
 		public:
-			UpdaterAppComponent(Nz::ApplicationBase& app);
+			UpdaterAppComponent(Nz::ApplicationBase& app, ConfigFile& configFile);
 			UpdaterAppComponent(const UpdaterAppComponent&) = delete;
 			UpdaterAppComponent(UpdaterAppComponent&&) = delete;
 			~UpdaterAppComponent() = default;
@@ -48,6 +50,7 @@ namespace tsom
 			Nz::FixedVector<std::shared_ptr<const DownloadManager::Download>, 3> m_updateArchives;
 			std::shared_ptr<const DownloadManager::Download> m_updaterDownload;
 			DownloadManager m_downloadManager;
+			ConfigFile& m_configFile;
 	};
 }
 

--- a/include/ServerLib/ServerInstance.hpp
+++ b/include/ServerLib/ServerInstance.hpp
@@ -17,6 +17,7 @@
 #include <NazaraUtils/Bitset.hpp>
 #include <NazaraUtils/MemoryPool.hpp>
 #include <NazaraUtils/PathUtils.hpp>
+#include <array>
 #include <memory>
 #include <unordered_set>
 #include <vector>
@@ -48,7 +49,9 @@ namespace tsom
 			template<typename F> void ForEachPlayer(F&& functor);
 			template<typename F> void ForEachPlayer(F&& functor) const;
 
+			inline Nz::ApplicationBase& GetApp();
 			inline const BlockLibrary& GetBlockLibrary() const;
+			inline const std::array<std::uint8_t, 32>& GetConnectionTokenEncryptionKey() const;
 			inline Planet& GetPlanet();
 			inline const Planet& GetPlanet() const;
 			inline Nz::EnttWorld& GetWorld();
@@ -61,6 +64,7 @@ namespace tsom
 			struct Config
 			{
 				std::filesystem::path saveDirectory = Nz::Utf8Path("save/chunks");
+				std::array<std::uint8_t, 32> connectionTokenEncryptionKey;
 				Nz::Time saveInterval = Nz::Time::Seconds(30);
 				Nz::UInt32 planetSeed = 42;
 				Nz::Vector3ui planetChunkCount = Nz::Vector3ui(5);
@@ -73,7 +77,7 @@ namespace tsom
 			void OnTick(Nz::Time elapsedTime);
 			void OnSave();
 
-			Nz::UInt16 m_tickIndex;
+			std::array<std::uint8_t, 32> m_connectionTokenEncryptionKey;
 			std::filesystem::path m_saveDirectory;
 			std::unique_ptr<Planet> m_planet;
 			std::unique_ptr<ChunkEntities> m_planetEntities;
@@ -87,6 +91,7 @@ namespace tsom
 			Nz::Time m_saveInterval;
 			Nz::Time m_tickAccumulator;
 			Nz::Time m_tickDuration;
+			Nz::UInt16 m_tickIndex;
 			BlockLibrary m_blockLibrary;
 			Nz::ApplicationBase& m_application;
 			bool m_pauseWhenEmpty;

--- a/include/ServerLib/ServerInstance.inl
+++ b/include/ServerLib/ServerInstance.inl
@@ -22,9 +22,19 @@ namespace tsom
 			functor(serverPlayer);
 	}
 
+	inline Nz::ApplicationBase& ServerInstance::GetApp()
+	{
+		return m_application;
+	}
+
 	inline const BlockLibrary& ServerInstance::GetBlockLibrary() const
 	{
 		return m_blockLibrary;
+	}
+
+	inline const std::array<std::uint8_t, 32>& ServerInstance::GetConnectionTokenEncryptionKey() const
+	{
+		return m_connectionTokenEncryptionKey;
 	}
 
 	inline Planet& ServerInstance::GetPlanet()

--- a/include/ServerLib/Session/InitialSessionHandler.hpp
+++ b/include/ServerLib/Session/InitialSessionHandler.hpp
@@ -23,9 +23,9 @@ namespace tsom
 
 			void HandlePacket(Packets::AuthRequest&& authRequest);
 
-			void OnDeserializationError(std::size_t packetIndex);
-			void OnUnexpectedPacket(std::size_t packetIndex);
-			void OnUnknownOpcode(Nz::UInt8 opcode);
+			void OnDeserializationError(std::size_t packetIndex) override;
+			void OnUnexpectedPacket(std::size_t packetIndex) override;
+			void OnUnknownOpcode(Nz::UInt8 opcode) override;
 
 		private:
 			ServerInstance& m_instance;

--- a/serverconfig.lua.default
+++ b/serverconfig.lua.default
@@ -1,6 +1,9 @@
 Api = {
 	Url = "https://tsom-api.digitalpulse.software"
 }
+ConnectionToken = {
+	EncryptionKey = ""
+}
 Server = {
 	Port = 29536,
 	SleepWhenEmpty = true

--- a/serverconfig.lua.default
+++ b/serverconfig.lua.default
@@ -1,3 +1,6 @@
+Api = {
+	Url = "https://tsom-api.digitalpulse.software"
+}
 Server = {
 	Port = 29536,
 	SleepWhenEmpty = true

--- a/src/CommonLib/Protocol/ConnectionToken.cpp
+++ b/src/CommonLib/Protocol/ConnectionToken.cpp
@@ -1,0 +1,99 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#include <CommonLib/Protocol/ConnectionToken.hpp>
+#include <NazaraUtils/Endianness.hpp>
+#include <sodium.h>
+#include <cassert>
+
+namespace tsom
+{
+	namespace Packets
+	{
+		void Serialize(PacketSerializer& serializer, ConnectionToken& token)
+		{
+			serializer &= token.tokenVersion;
+			if (serializer.IsWriting())
+				serializer.Write(token.tokenNonce.data(), token.tokenNonce.size());
+			else
+				serializer.Read(token.tokenNonce.data(), token.tokenNonce.size());
+
+			serializer &= token.creationTimestamp;
+			serializer &= token.expireTimestamp;
+
+			if (serializer.IsWriting())
+			{
+				serializer.Write(token.encryption.keyClientToServer.data(), token.encryption.keyClientToServer.size());
+				serializer.Write(token.encryption.keyServerToClient.data(), token.encryption.keyServerToClient.size());
+			}
+			else
+			{
+				serializer.Read(token.encryption.keyClientToServer.data(), token.encryption.keyClientToServer.size());
+				serializer.Read(token.encryption.keyServerToClient.data(), token.encryption.keyServerToClient.size());
+			}
+
+			serializer &= token.gameServer.address;
+			serializer &= token.gameServer.port;
+
+			if (serializer.IsWriting())
+				serializer.Write(token.privateToken.data(), token.privateToken.size());
+			else
+				serializer.Read(token.privateToken.data(), token.privateToken.size());
+		}
+
+		void Serialize(PacketSerializer& serializer, ConnectionTokenPrivate& token)
+		{
+			if (serializer.IsWriting())
+			{
+				serializer.Write(token.encryption.keyClientToServer.data(), token.encryption.keyClientToServer.size());
+				serializer.Write(token.encryption.keyServerToClient.data(), token.encryption.keyServerToClient.size());
+			}
+			else
+			{
+				serializer.Read(token.encryption.keyClientToServer.data(), token.encryption.keyClientToServer.size());
+				serializer.Read(token.encryption.keyServerToClient.data(), token.encryption.keyServerToClient.size());
+			}
+
+			serializer &= token.api.url;
+			serializer &= token.api.token;
+
+			serializer &= token.player.guid;
+			serializer &= token.player.nickname;
+		}
+	}
+
+	ConnectionTokenAuth ConnectionTokenPrivate::AuthAndDecrypt(std::span<const Nz::UInt8> tokenData, Nz::UInt32 tokenVersion, Nz::UInt64 expireTimestamp, std::span<const Nz::UInt8, 12> nonce, std::span<const Nz::UInt8, 32> key, ConnectionTokenPrivate* token)
+	{
+		assert(token);
+
+		std::vector<Nz::UInt8> tokenBinary(ConnectionToken::TokenPrivateMaxSize);
+		unsigned long long tokenBinarySize = ConnectionToken::TokenPrivateMaxSize;
+
+		// Serialize additional data
+		std::array<Nz::UInt8, sizeof(tokenVersion) + sizeof(expireTimestamp)> additionalData;
+		{
+			Nz::UInt32 tokenVersionLE = Nz::HostToLittleEndian(tokenVersion);
+			Nz::UInt64 expireTimestampLE = Nz::HostToLittleEndian(expireTimestamp);
+
+			std::memcpy(&additionalData[0], &tokenVersionLE, sizeof(tokenVersionLE));
+			std::memcpy(&additionalData[sizeof(tokenVersionLE)], &expireTimestampLE, sizeof(expireTimestampLE));
+		}
+
+		if (crypto_aead_xchacha20poly1305_ietf_decrypt(tokenBinary.data(), &tokenBinarySize, nullptr, tokenData.data(), tokenData.size(), additionalData.data(), additionalData.size(), nonce.data(), key.data()) != 0)
+			return ConnectionTokenAuth::ForgedToken;
+
+		try
+		{
+			Nz::ByteStream byteStream(tokenBinary.data(), tokenBinarySize);
+			PacketSerializer serializer(byteStream, false, tokenVersion);
+			Packets::Serialize(serializer, *token);
+		}
+		catch (const std::exception& e)
+		{
+			return ConnectionTokenAuth::CorruptToken;
+		}
+
+		return ConnectionTokenAuth::Success;
+	}
+}

--- a/src/CommonLib/Protocol/Packets.cpp
+++ b/src/CommonLib/Protocol/Packets.cpp
@@ -19,6 +19,7 @@ namespace tsom
 	{
 		switch (authError)
 		{
+			case AuthError::InvalidToken: return "Invalid connection token";
 			case AuthError::ProtocolError: return "A protocol error occurred";
 			case AuthError::ServerIsOutdated: return "Server is outdated";
 			case AuthError::UpgradeRequired: return "Game version upgrade required";

--- a/src/Game/GameAppComponent.cpp
+++ b/src/Game/GameAppComponent.cpp
@@ -16,6 +16,7 @@
 #include <Game/States/ConnectionState.hpp>
 #include <Game/States/DebugInfoState.hpp>
 #include <Game/States/MenuState.hpp>
+#include <Game/States/VersionCheckState.hpp>
 #include <Nazara/Core/ApplicationBase.hpp>
 #include <Nazara/Core/Clock.hpp>
 #include <Nazara/Core/EntitySystemAppComponent.hpp>
@@ -25,7 +26,6 @@
 #include <Nazara/Graphics/RenderWindow.hpp>
 #include <Nazara/Graphics/Components/CameraComponent.hpp>
 #include <Nazara/Graphics/Systems/RenderSystem.hpp>
-#include <Nazara/Network/WebServiceAppComponent.hpp>
 #include <Nazara/Physics3D/Systems/Physics3DSystem.hpp>
 #include <Nazara/Platform/MessageBox.hpp>
 #include <Nazara/Platform/WindowingAppComponent.hpp>
@@ -62,6 +62,7 @@ namespace tsom
 			m_stateMachine.PushState(std::make_shared<tsom::DebugInfoState>(stateData));
 			m_stateMachine.PushState(std::move(connectionState));
 			m_stateMachine.PushState(std::make_shared<tsom::BackgroundState>(stateData));
+			m_stateMachine.PushState(std::make_shared<tsom::VersionCheckState>(stateData));
 			m_stateMachine.PushState(std::make_shared<tsom::MenuState>(stateData));
 		}
 	}

--- a/src/Game/GameConfigAppComponent.cpp
+++ b/src/Game/GameConfigAppComponent.cpp
@@ -11,6 +11,7 @@ namespace tsom
 {
 	GameConfigFile::GameConfigFile()
 	{
+		RegisterStringOption("Api.Url");
 		RegisterStringOption("Menu.Login", "Mingebag", [](std::string value) -> Nz::Result<std::string, std::string>
 		{
 			if (value.empty())
@@ -23,6 +24,14 @@ namespace tsom
 		});
 
 		RegisterStringOption("Menu.ServerAddress", "tsom.digitalpulse.software");
+		RegisterStringOption("Player.Token", "", [](std::string value) -> Nz::Result<std::string, std::string>
+		{
+			if (value.size() > 64)
+				return Nz::Err("Invalid token");
+
+			return Nz::Ok(std::move(value));
+		});
+
 		RegisterIntegerOption("Server.Port", 1, 0xFFFF, 29536);
 	}
 

--- a/src/Game/States/AuthenticationState.cpp
+++ b/src/Game/States/AuthenticationState.cpp
@@ -1,0 +1,119 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+#if 0
+
+#include <Game/States/AuthenticationState.hpp>
+#include <Game/GameConfigAppComponent.hpp>
+#include <Nazara/Core/ApplicationBase.hpp>
+#include <Nazara/Network/WebServiceAppComponent.hpp>
+#include <Nazara/TextRenderer/SimpleTextDrawer.hpp>
+#include <Nazara/Widgets/LabelWidget.hpp>
+#include <fmt/core.h>
+
+namespace nlohmann
+{
+	template<>
+	struct adl_serializer<semver::version>
+	{
+		static void from_json(const nlohmann::json& json, semver::version& downloadInfo)
+		{
+			downloadInfo.from_string(json.template get<std::string_view>());
+		}
+	};
+
+	template<>
+	struct adl_serializer<tsom::UpdateInfo::DownloadInfo>
+	{
+		static void from_json(const nlohmann::json& json, tsom::UpdateInfo::DownloadInfo& downloadInfo)
+		{
+			downloadInfo.downloadUrl = json.at("download_url");
+			downloadInfo.size = json.at("size");
+			downloadInfo.sha256 = json.value("sha256", "");
+		}
+	};
+
+	template<>
+	struct adl_serializer<tsom::UpdateInfo>
+	{
+		static void from_json(const nlohmann::json& json, tsom::UpdateInfo& updateInfo)
+		{
+			updateInfo.assetVersion = json.at("assets_version");
+			updateInfo.binaryVersion = json.at("version");
+			updateInfo.assets = json.at("assets");
+			updateInfo.binaries = json.at("binaries");
+			updateInfo.updater = json.at("updater");
+		}
+	};
+}
+
+namespace tsom
+{
+	AuthenticationState::AuthenticationState(std::shared_ptr<StateData> stateData, std::shared_ptr<Nz::State> previousState, std::string_view token) :
+	WidgetState(std::move(stateData)),
+	m_previousState(std::move(previousState))
+	{
+		m_statusLabel = CreateWidget<Nz::LabelWidget>();
+
+		auto& webService = GetStateData().app->GetComponent<Nz::WebServiceAppComponent>();
+
+		webService.QueueRequest([&](Nz::WebRequest& request)
+		{
+			auto& gameConfig = GetStateData().app->GetComponent<GameConfigAppComponent>().GetConfig();
+
+			request.SetupPost();
+			request.SetURL(fmt::format("{}/v1/player/authenticate", gameConfig.GetStringValue("Api.Url")));
+			request.SetServiceName("TSOM Authentication");
+			request.SetResultCallback([this](Nz::WebRequestResult&& result)
+			{
+				if (!result.HasSucceeded())
+				{
+					UpdateStatus(Nz::SimpleTextDrawer::Draw(fmt::format("failed to authenticate: {}", result.GetErrorMessage()), 36, Nz::TextStyle_Regular, Nz::Color::Red()));
+					m_nextState = m_previousState;
+					m_nextStateTimer = Nz::Time::Seconds(3);
+					return;
+				}
+
+				if (result.GetStatusCode() != 200)
+				{
+					//TODO: parse errors
+					UpdateStatus(Nz::SimpleTextDrawer::Draw(fmt::format("failed to authenticate: {}", result.GetErrorMessage()), 36, Nz::TextStyle_Regular, Nz::Color::Red()));
+					m_nextState = m_previousState;
+					m_nextStateTimer = Nz::Time::Seconds(3);
+					return;
+				}
+
+				UpdateInfo updateInfo;
+				try
+				{
+					updateInfo = nlohmann::json::parse(result.GetBody());
+				}
+				catch (const std::exception& e)
+				{
+					cb(Nz::Err(fmt::format("failed to parse version data: {0}", e.what())));
+					return;
+				}
+
+			});
+
+			return true;
+		});
+	}
+
+	void AuthenticationState::LayoutWidgets(const Nz::Vector2f& newSize)
+	{
+		m_statusLabel->SetPosition(newSize * Nz::Vector2f(0.5f, 0.9f) - m_statusLabel->GetSize() * 0.5f);
+	}
+
+	void AuthenticationState::UpdateStatus(const Nz::AbstractTextDrawer& textDrawer)
+	{
+		m_statusLabel->UpdateText(textDrawer);
+		m_statusLabel->Resize(m_statusLabel->GetPreferredSize());
+		m_statusLabel->Center();
+		m_statusLabel->Show();
+
+		LayoutWidgets(GetStateData().canvas->GetSize());
+	}
+}
+
+#endif

--- a/src/Game/States/AuthenticationState.hpp
+++ b/src/Game/States/AuthenticationState.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#pragma once
+
+#ifndef TSOM_GAME_STATES_AUTHENTICATIONSTATE_HPP
+#define TSOM_GAME_STATES_AUTHENTICATIONSTATE_HPP
+
+#include <Game/States/StateData.hpp>
+#include <Game/States/WidgetState.hpp>
+#include <Nazara/Core/Time.hpp>
+
+namespace Nz
+{
+	class AbstractTextDrawer;
+	class LabelWidget;
+}
+
+namespace tsom
+{
+	class AuthenticationState : public WidgetState
+	{
+		public:
+			AuthenticationState(std::shared_ptr<StateData> stateData, std::shared_ptr<Nz::State> previousState, std::string_view token);
+			~AuthenticationState() = default;
+
+			void LayoutWidgets(const Nz::Vector2f& newSize) override;
+
+		private:
+			void UpdateStatus(const Nz::AbstractTextDrawer& textDrawer);
+
+			std::shared_ptr<Nz::State> m_nextState;
+			std::shared_ptr<Nz::State> m_previousState;
+			Nz::LabelWidget* m_statusLabel;
+			Nz::Time m_nextStateTimer;
+	};
+}
+
+#include <Game/States/AuthenticationState.inl>
+
+#endif // TSOM_GAME_STATES_AUTHENTICATIONSTATE_HPP

--- a/src/Game/States/AuthenticationState.inl
+++ b/src/Game/States/AuthenticationState.inl
@@ -1,0 +1,7 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+namespace tsom
+{
+}

--- a/src/Game/States/ConnectionState.cpp
+++ b/src/Game/States/ConnectionState.cpp
@@ -70,12 +70,11 @@ namespace tsom
 			}
 			else
 			{
+				Disconnect();
 				UpdateStatus(Nz::SimpleTextDrawer::Draw(fmt::format("Authentication failed: {0}", ToString(authResponse.authResult.GetError())), 36, Nz::TextStyle_Regular, Nz::Color::Red()));
 
 				m_nextState = m_previousState;
 				m_nextStateTimer = Nz::Time::Seconds(3);
-
-				Disconnect();
 			}
 		});
 

--- a/src/Game/States/ConnectionState.cpp
+++ b/src/Game/States/ConnectionState.cpp
@@ -119,7 +119,7 @@ namespace tsom
 
 			Packets::AuthRequest request;
 			request.gameVersion = GameVersion;
-			request.nickname = m_nickname;
+			request.token.emplace<Packets::AuthRequest::AnonymousPlayerData>().nickname = m_nickname;
 
 			m_serverSession->SendPacket(request);
 		};

--- a/src/Game/States/ConnectionState.cpp
+++ b/src/Game/States/ConnectionState.cpp
@@ -24,12 +24,12 @@ namespace tsom
 		m_connectingLabel = CreateWidget<Nz::LabelWidget>();
 	}
 
-	void ConnectionState::Connect(const Nz::IpAddress& serverAddress, std::string nickname, std::shared_ptr<Nz::State> previousState)
+	void ConnectionState::Connect(const Nz::IpAddress& serverAddress, std::variant<Packets::AuthRequest::AuthenticatedPlayerData, Packets::AuthRequest::AnonymousPlayerData> playerData, std::shared_ptr<Nz::State> previousState)
 	{
 		Disconnect();
 
 		m_previousState = std::move(previousState);
-		m_nickname = std::move(nickname);
+		m_playerData = std::move(playerData);
 
 		// Find a compatible reactor
 		NetworkReactor* reactor = nullptr;
@@ -119,7 +119,7 @@ namespace tsom
 
 			Packets::AuthRequest request;
 			request.gameVersion = GameVersion;
-			request.token.emplace<Packets::AuthRequest::AnonymousPlayerData>().nickname = m_nickname;
+			request.token = m_playerData;
 
 			m_serverSession->SendPacket(request);
 		};

--- a/src/Game/States/ConnectionState.hpp
+++ b/src/Game/States/ConnectionState.hpp
@@ -35,7 +35,7 @@ namespace tsom
 			ConnectionState(std::shared_ptr<StateData> stateData);
 			~ConnectionState() = default;
 
-			void Connect(const Nz::IpAddress& serverAddress, std::string nickname, std::shared_ptr<Nz::State> previousState);
+			void Connect(const Nz::IpAddress& serverAddress, std::variant<Packets::AuthRequest::AuthenticatedPlayerData, Packets::AuthRequest::AnonymousPlayerData> playerData, std::shared_ptr<Nz::State> previousState);
 			void Disconnect();
 
 			inline const ConnectionInfo* GetConnectionInfo() const;
@@ -66,9 +66,9 @@ namespace tsom
 			std::optional<ConnectionInfo> m_connectionInfo;
 			std::optional<NetworkSession> m_serverSession;
 			std::shared_ptr<Nz::State> m_connectedState;
-			std::shared_ptr<Nz::State> m_previousState;
 			std::shared_ptr<Nz::State> m_nextState;
-			std::string m_nickname;
+			std::shared_ptr<Nz::State> m_previousState;
+			std::variant<Packets::AuthRequest::AuthenticatedPlayerData, Packets::AuthRequest::AnonymousPlayerData> m_playerData;
 			Nz::HighPrecisionClock m_sessionInfoClock;
 			Nz::FixedVector<NetworkReactor, 2> m_reactors;
 			Nz::LabelWidget* m_connectingLabel;

--- a/src/Game/States/CreatePlayerState.cpp
+++ b/src/Game/States/CreatePlayerState.cpp
@@ -155,7 +155,6 @@ namespace tsom
 	void CreatePlayerState::UpdateStatus(const Nz::AbstractTextDrawer& textDrawer)
 	{
 		m_status->UpdateText(textDrawer);
-		m_status->Resize(m_status->GetPreferredSize());
 		m_status->Center();
 		m_status->Show();
 

--- a/src/Game/States/CreatePlayerState.cpp
+++ b/src/Game/States/CreatePlayerState.cpp
@@ -120,7 +120,7 @@ namespace tsom
 					{
 						nlohmann::json error = nlohmann::json::parse(result.GetBody());
 
-						std::string_view errorMessage = error["err_desc"];
+						std::string errorMessage = error["err_desc"];
 						UpdateStatus(Nz::SimpleTextDrawer::Draw(fmt::format("Failed to create player: {}", errorMessage), 36, Nz::TextStyle_Regular, Nz::Color::Red()));
 					}
 					catch (const std::exception& e)
@@ -134,8 +134,8 @@ namespace tsom
 
 				nlohmann::json responseDoc = nlohmann::json::parse(result.GetBody());
 
-				std::string_view playerGuid = responseDoc["guid"];
-				std::string_view connectToken = responseDoc["token"];
+				std::string playerGuid = responseDoc["guid"];
+				std::string connectToken = responseDoc["token"];
 
 				gameConfig.SetStringValue("Player.Token", std::string(connectToken));
 

--- a/src/Game/States/CreatePlayerState.cpp
+++ b/src/Game/States/CreatePlayerState.cpp
@@ -1,0 +1,164 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#include <Game/States/CreatePlayerState.hpp>
+#include <CommonLib/GameConstants.hpp>
+#include <CommonLib/InternalConstants.hpp>
+#include <CommonLib/UpdaterAppComponent.hpp>
+#include <CommonLib/Version.hpp>
+#include <Game/GameConfigAppComponent.hpp>
+#include <Game/States/ConnectionState.hpp>
+#include <Game/States/GameState.hpp>
+#include <Game/States/UpdateState.hpp>
+#include <Nazara/Widgets.hpp>
+#include <Nazara/Core/ApplicationBase.hpp>
+#include <Nazara/Core/StateMachine.hpp>
+#include <Nazara/Core/StringExt.hpp>
+#include <Nazara/Network/Algorithm.hpp>
+#include <Nazara/Network/IpAddress.hpp>
+#include <Nazara/Network/Network.hpp>
+#include <Nazara/Network/WebServiceAppComponent.hpp>
+#include <Nazara/TextRenderer/SimpleTextDrawer.hpp>
+#include <fmt/color.h>
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+#include <optional>
+
+namespace tsom
+{
+	CreatePlayerState::CreatePlayerState(std::shared_ptr<StateData> stateData, std::shared_ptr<Nz::State> previousState) :
+	WidgetState(stateData),
+	m_previousState(std::move(previousState)),
+	m_nextStateTimer(Nz::Time::Zero())
+	{
+		m_status = CreateWidget<Nz::LabelWidget>();
+
+		m_layout = CreateWidget<Nz::BoxLayout>(Nz::BoxLayoutOrientation::TopToBottom);
+
+		Nz::BoxLayout* nicknameLayout = m_layout->Add<Nz::BoxLayout>(Nz::BoxLayoutOrientation::LeftToRight);
+
+		Nz::SimpleLabelWidget* nicknameLabel = nicknameLayout->Add<Nz::SimpleLabelWidget>();
+		nicknameLabel->SetText("Nickname:");
+		nicknameLabel->SetMaximumWidth(nicknameLabel->GetPreferredWidth());
+
+		Nz::TextAreaWidget* nicknameText = nicknameLayout->Add<Nz::TextAreaWidget>();
+		nicknameText->EnableBackground(true);
+		nicknameText->SetCharacterSize(24);
+		nicknameText->SetTextColor(Nz::Color::Black());
+
+		Nz::ButtonWidget* createButton = m_layout->Add<Nz::ButtonWidget>();
+		createButton->UpdateText(Nz::SimpleTextDrawer::Draw("Create player", 24, Nz::TextStyle_Regular, Nz::Color::Black()));
+		createButton->SetMaximumWidth(createButton->GetPreferredWidth() * 1.5f);
+		ConnectSignal(createButton->OnButtonTrigger, [this, nicknameText](const Nz::ButtonWidget* /*button*/)
+		{
+			OnCreatePressed(nicknameText->GetText());
+		});
+
+		Nz::ButtonWidget* backButton = m_layout->Add<Nz::ButtonWidget>();
+		backButton->UpdateText(Nz::SimpleTextDrawer::Draw("Back", 24, Nz::TextStyle_Regular, Nz::Color::Black()));
+		backButton->SetMaximumWidth(backButton->GetPreferredWidth() * 1.5f);
+		ConnectSignal(backButton->OnButtonTrigger, [&](const Nz::ButtonWidget* /*button*/)
+		{
+			m_nextState = m_previousState;
+		});
+	}
+
+	bool CreatePlayerState::Update(Nz::StateMachine& fsm, Nz::Time elapsedTime)
+	{
+		if (m_nextState)
+		{
+			m_nextStateTimer -= elapsedTime;
+			if (m_nextStateTimer <= Nz::Time::Zero())
+			{
+				fsm.ChangeState(std::move(m_nextState));
+				return true;
+			}
+		}
+
+		return true;
+	}
+
+	void CreatePlayerState::LayoutWidgets(const Nz::Vector2f& newSize)
+	{
+		m_status->SetPosition(newSize * Nz::Vector2f(0.5f, 0.8f) - m_status->GetSize() * 0.5f);
+
+		m_layout->Resize({ newSize.x * 0.2f, m_layout->GetPreferredHeight() });
+		m_layout->Center();
+	}
+
+	void CreatePlayerState::OnCreatePressed(const std::string& nickname)
+	{
+		auto& gameConfigComponent = GetStateData().app->GetComponent<GameConfigAppComponent>();
+		auto& gameConfig = gameConfigComponent.GetConfig();
+		auto& webService = GetStateData().app->GetComponent<Nz::WebServiceAppComponent>();
+
+		webService.QueueRequest([&, nickname](Nz::WebRequest& request) mutable
+		{
+			request.SetupPost();
+			request.SetURL(fmt::format("{}/v1/players", gameConfig.GetStringValue("Api.Url"), BuildConfig));
+			request.SetServiceName("TSOM Player Create");
+
+			nlohmann::json createParams;
+			createParams["nickname"] = nickname;
+
+			request.SetJSonContent(createParams.dump());
+
+			request.SetResultCallback([&, nickname = std::move(nickname)](Nz::WebRequestResult&& result)
+			{
+				if (!result.HasSucceeded())
+				{
+					fmt::print(fg(fmt::color::red), "failed to create player: {}\n", result.GetErrorMessage());
+					return;
+				}
+
+				if (result.GetStatusCode() != 200)
+				{
+					fmt::print(fg(fmt::color::red), "failed to create player (error {})\n", result.GetStatusCode());
+
+					try
+					{
+						nlohmann::json error = nlohmann::json::parse(result.GetBody());
+
+						std::string_view errorMessage = error["err_desc"];
+						UpdateStatus(Nz::SimpleTextDrawer::Draw(fmt::format("Failed to create player: {}", errorMessage), 36, Nz::TextStyle_Regular, Nz::Color::Red()));
+					}
+					catch (const std::exception& e)
+					{
+						fmt::print(fg(fmt::color::red), "failed to decode error from API: {}\n", e.what());
+						UpdateStatus(Nz::SimpleTextDrawer::Draw("Failed to create player", 36, Nz::TextStyle_Regular, Nz::Color::Red()));
+					}
+
+					return;
+				}
+
+				nlohmann::json responseDoc = nlohmann::json::parse(result.GetBody());
+
+				std::string_view playerGuid = responseDoc["guid"];
+				std::string_view connectToken = responseDoc["token"];
+
+				gameConfig.SetStringValue("Player.Token", std::string(connectToken));
+
+				gameConfigComponent.Save();
+
+				fmt::print(fg(fmt::color::green), "created player {}\n", nickname);
+
+				UpdateStatus(Nz::SimpleTextDrawer::Draw(fmt::format("Player {} has been created!", nickname), 48, Nz::TextStyle_Regular, Nz::Color::Green()));
+				m_nextState = m_previousState;
+				m_nextStateTimer = Nz::Time::Seconds(2.f);
+			});
+
+			return true;
+		});
+	}
+
+	void CreatePlayerState::UpdateStatus(const Nz::AbstractTextDrawer& textDrawer)
+	{
+		m_status->UpdateText(textDrawer);
+		m_status->Resize(m_status->GetPreferredSize());
+		m_status->Center();
+		m_status->Show();
+
+		LayoutWidgets(GetStateData().canvas->GetSize());
+	}
+}

--- a/src/Game/States/CreatePlayerState.cpp
+++ b/src/Game/States/CreatePlayerState.cpp
@@ -134,7 +134,7 @@ namespace tsom
 
 				nlohmann::json responseDoc = nlohmann::json::parse(result.GetBody());
 
-				std::string playerGuid = responseDoc["guid"];
+				std::string playerUuid = responseDoc["uuid"];
 				std::string connectToken = responseDoc["token"];
 
 				gameConfig.SetStringValue("Player.Token", std::string(connectToken));

--- a/src/Game/States/CreatePlayerState.hpp
+++ b/src/Game/States/CreatePlayerState.hpp
@@ -4,48 +4,46 @@
 
 #pragma once
 
-#ifndef TSOM_GAME_STATES_MENUSTATE_HPP
-#define TSOM_GAME_STATES_MENUSTATE_HPP
+#ifndef TSOM_GAME_STATES_CREATEPLAYERSTATE_HPP
+#define TSOM_GAME_STATES_CREATEPLAYERSTATE_HPP
 
 #include <CommonLib/UpdateInfo.hpp>
 #include <Game/States/WidgetState.hpp>
+#include <Nazara/Core/Time.hpp>
 #include <string>
 
 namespace Nz
 {
+	class AbstractTextDrawer;
 	class BoxLayout;
-	class ButtonWidget;
 	class LabelWidget;
-	class SimpleLabelWidget;
 }
 
 namespace tsom
 {
 	class ConnectionState;
 
-	class MenuState : public WidgetState
+	class CreatePlayerState : public WidgetState
 	{
 		public:
-			MenuState(std::shared_ptr<StateData> stateData);
-			~MenuState() = default;
+			CreatePlayerState(std::shared_ptr<StateData> stateData, std::shared_ptr<Nz::State> previousState);
+			~CreatePlayerState() = default;
 
 			bool Update(Nz::StateMachine& fsm, Nz::Time elapsedTime) override;
 
 		private:
 			void LayoutWidgets(const Nz::Vector2f& newSize) override;
+			void OnCreatePressed(const std::string& nickname);
+			void UpdateStatus(const Nz::AbstractTextDrawer& textDrawer);
 
-			std::optional<UpdateInfo> m_newVersionInfo;
+			std::shared_ptr<Nz::State> m_previousState;
 			std::shared_ptr<Nz::State> m_nextState;
-			Nz::Time m_accumulator;
 			Nz::BoxLayout* m_layout;
-			Nz::SimpleLabelWidget* m_logo;
-			Nz::SimpleLabelWidget* m_logoBackground;
-			Nz::ButtonWidget* m_playButton;
-			Nz::ButtonWidget* m_quitGameButton;
-			bool m_autoConnect;
+			Nz::LabelWidget* m_status;
+			Nz::Time m_nextStateTimer;
 	};
 }
 
-#include <Game/States/MenuState.inl>
+#include <Game/States/CreatePlayerState.inl>
 
-#endif // TSOM_GAME_STATES_MENUSTATE_HPP
+#endif // TSOM_GAME_STATES_CREATEPLAYERSTATE_HPP

--- a/src/Game/States/CreatePlayerState.inl
+++ b/src/Game/States/CreatePlayerState.inl
@@ -1,0 +1,7 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+namespace tsom
+{
+}

--- a/src/Game/States/DirectConnectionState.cpp
+++ b/src/Game/States/DirectConnectionState.cpp
@@ -1,0 +1,149 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#include <Game/States/DirectConnectionState.hpp>
+#include <CommonLib/GameConstants.hpp>
+#include <CommonLib/InternalConstants.hpp>
+#include <CommonLib/UpdaterAppComponent.hpp>
+#include <CommonLib/Version.hpp>
+#include <Game/GameConfigAppComponent.hpp>
+#include <Game/States/ConnectionState.hpp>
+#include <Game/States/GameState.hpp>
+#include <Game/States/UpdateState.hpp>
+#include <Nazara/Widgets.hpp>
+#include <Nazara/Core/ApplicationBase.hpp>
+#include <Nazara/Core/StateMachine.hpp>
+#include <Nazara/Core/StringExt.hpp>
+#include <Nazara/Network/Algorithm.hpp>
+#include <Nazara/Network/IpAddress.hpp>
+#include <Nazara/Network/Network.hpp>
+#include <Nazara/Network/WebServiceAppComponent.hpp>
+#include <Nazara/TextRenderer/SimpleTextDrawer.hpp>
+#include <fmt/color.h>
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+#include <optional>
+
+namespace tsom
+{
+	DirectConnectionState::DirectConnectionState(std::shared_ptr<StateData> stateData, std::shared_ptr<Nz::State> previousState) :
+	WidgetState(stateData),
+	m_previousState(std::move(previousState))
+	{
+		auto& gameConfig = GetStateData().app->GetComponent<GameConfigAppComponent>().GetConfig();
+
+		std::string_view address = gameConfig.GetStringValue("Menu.ServerAddress");
+		std::string_view nickname = gameConfig.GetStringValue("Menu.Login");
+
+		const Nz::CommandLineParameters& cmdParams = GetStateData().app->GetCommandLineParameters();
+		cmdParams.GetParameter("server-address", &address);
+		cmdParams.GetParameter("nickname", &nickname);
+
+		m_layout = CreateWidget<Nz::BoxLayout>(Nz::BoxLayoutOrientation::TopToBottom);
+
+		Nz::BoxLayout* addressLayout = m_layout->Add<Nz::BoxLayout>(Nz::BoxLayoutOrientation::LeftToRight);
+
+		Nz::LabelWidget* serverLabel = addressLayout->Add<Nz::LabelWidget>();
+		serverLabel->UpdateText(Nz::SimpleTextDrawer::Draw("Server: ", 24));
+
+		m_serverAddressArea = addressLayout->Add<Nz::TextAreaWidget>();
+		m_serverAddressArea->EnableBackground(true);
+		m_serverAddressArea->SetCharacterSize(24);
+		m_serverAddressArea->SetText(std::string(address));
+		m_serverAddressArea->SetTextColor(Nz::Color::Black());
+
+		Nz::BoxLayout* loginLayout = m_layout->Add<Nz::BoxLayout>(Nz::BoxLayoutOrientation::LeftToRight);
+
+		Nz::LabelWidget* loginLabel = loginLayout->Add<Nz::LabelWidget>();
+		loginLabel->UpdateText(Nz::SimpleTextDrawer::Draw("Login: ", 24));
+
+		m_loginArea = loginLayout->Add<Nz::TextAreaWidget>();
+		m_loginArea->EnableBackground(true);
+		m_loginArea->SetCharacterSize(24);
+		m_loginArea->SetText(std::string(nickname));
+		m_loginArea->SetTextColor(Nz::Color::Black());
+
+		m_connectButton = m_layout->Add<Nz::ButtonWidget>();
+		m_connectButton->UpdateText(Nz::SimpleTextDrawer::Draw("Connect", 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+		m_connectButton->SetMaximumWidth(m_connectButton->GetPreferredWidth() * 1.5f);
+		ConnectSignal(m_connectButton->OnButtonTrigger, [this](const Nz::ButtonWidget*)
+		{
+			OnConnectPressed();
+		});
+
+		Nz::ButtonWidget* backButton = m_layout->Add<Nz::ButtonWidget>();
+		backButton->UpdateText(Nz::SimpleTextDrawer::Draw("Back", 24, Nz::TextStyle_Regular, Nz::Color::Black()));
+		backButton->SetMaximumWidth(backButton->GetPreferredWidth() * 1.5f);
+		ConnectSignal(backButton->OnButtonTrigger, [&](const Nz::ButtonWidget*)
+		{
+			m_nextState = m_previousState;
+		});
+
+		m_autoConnect = cmdParams.HasFlag("auto-connect");
+	}
+
+	bool DirectConnectionState::Update(Nz::StateMachine& fsm, Nz::Time elapsedTime)
+	{
+		if (m_nextState)
+		{
+			fsm.ChangeState(std::move(m_nextState));
+			return true;
+		}
+
+		if (m_autoConnect)
+		{
+			OnConnectPressed();
+			m_autoConnect = false;
+		}
+
+		return true;
+	}
+
+	void DirectConnectionState::LayoutWidgets(const Nz::Vector2f& newSize)
+	{
+		m_layout->Resize({ newSize.x * 0.2f, m_layout->GetPreferredHeight() });
+		m_layout->Center();
+	}
+
+	void DirectConnectionState::OnConnectPressed()
+	{
+		if (m_serverAddressArea->GetText().empty())
+		{
+			fmt::print(fg(fmt::color::red), "missing server address\n");
+			return;
+		}
+
+		std::string login = std::string(Nz::Trim(m_loginArea->GetText(), Nz::UnicodeAware{}));
+		if (login.empty())
+		{
+			fmt::print(fg(fmt::color::red), "login cannot be blank\n");
+			return;
+		}
+
+		auto& gameConfig = GetStateData().app->GetComponent<GameConfigAppComponent>();
+		Nz::UInt16 serverPort = gameConfig.GetConfig().GetIntegerValue<Nz::UInt16>("Server.Port");
+
+		Nz::ResolveError resolveError;
+		auto hostVec = Nz::IpAddress::ResolveHostname(Nz::NetProtocol::Any, m_serverAddressArea->GetText(), std::to_string(serverPort), &resolveError);
+
+		if (hostVec.empty())
+		{
+			fmt::print(fg(fmt::color::red), "failed to resolve {}: {}\n", m_serverAddressArea->GetText(), Nz::ErrorToString(resolveError));
+			return;
+		}
+
+		gameConfig.GetConfig().SetStringValue("Menu.Login", login);
+		gameConfig.GetConfig().SetStringValue("Menu.ServerAddress", m_serverAddressArea->GetText());
+
+		gameConfig.Save();
+
+		Nz::IpAddress serverAddress = hostVec[0].address;
+
+		fmt::print("connecting to {}...\n", serverAddress.ToString());
+
+		auto& stateData = GetStateData();
+		if (stateData.connectionState)
+			stateData.connectionState->Connect(serverAddress, login, shared_from_this());
+	}
+}

--- a/src/Game/States/DirectConnectionState.cpp
+++ b/src/Game/States/DirectConnectionState.cpp
@@ -144,6 +144,11 @@ namespace tsom
 
 		auto& stateData = GetStateData();
 		if (stateData.connectionState)
-			stateData.connectionState->Connect(serverAddress, login, shared_from_this());
+		{
+			Packets::AuthRequest::AnonymousPlayerData anonymousPlayer;
+			anonymousPlayer.nickname = login;
+
+			stateData.connectionState->Connect(serverAddress, std::move(anonymousPlayer), shared_from_this());
+		}
 	}
 }

--- a/src/Game/States/DirectConnectionState.hpp
+++ b/src/Game/States/DirectConnectionState.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#ifndef TSOM_GAME_STATES_DIRECTCONNECTSTATE_HPP
-#define TSOM_GAME_STATES_DIRECTCONNECTSTATE_HPP
+#ifndef TSOM_GAME_STATES_DIRECTCONNECTIONSTATE_HPP
+#define TSOM_GAME_STATES_DIRECTCONNECTIONSTATE_HPP
 
 #include <Game/States/WidgetState.hpp>
 #include <string>
@@ -44,4 +44,4 @@ namespace tsom
 
 #include <Game/States/DirectConnectionState.inl>
 
-#endif // TSOM_GAME_STATES_DIRECTCONNECTSTATE_HPP
+#endif // TSOM_GAME_STATES_DIRECTCONNECTIONSTATE_HPP

--- a/src/Game/States/DirectConnectionState.hpp
+++ b/src/Game/States/DirectConnectionState.hpp
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#ifndef TSOM_GAME_STATES_MENUSTATE_HPP
-#define TSOM_GAME_STATES_MENUSTATE_HPP
+#ifndef TSOM_GAME_STATES_DIRECTCONNECTSTATE_HPP
+#define TSOM_GAME_STATES_DIRECTCONNECTSTATE_HPP
 
-#include <CommonLib/UpdateInfo.hpp>
 #include <Game/States/WidgetState.hpp>
 #include <string>
 
@@ -16,36 +15,33 @@ namespace Nz
 	class BoxLayout;
 	class ButtonWidget;
 	class LabelWidget;
-	class SimpleLabelWidget;
+	class TextAreaWidget;
 }
 
 namespace tsom
 {
-	class ConnectionState;
-
-	class MenuState : public WidgetState
+	class DirectConnectionState : public WidgetState
 	{
 		public:
-			MenuState(std::shared_ptr<StateData> stateData);
-			~MenuState() = default;
+			DirectConnectionState(std::shared_ptr<StateData> stateData, std::shared_ptr<Nz::State> previousState);
+			~DirectConnectionState() = default;
 
 			bool Update(Nz::StateMachine& fsm, Nz::Time elapsedTime) override;
 
 		private:
 			void LayoutWidgets(const Nz::Vector2f& newSize) override;
+			void OnConnectPressed();
 
-			std::optional<UpdateInfo> m_newVersionInfo;
 			std::shared_ptr<Nz::State> m_nextState;
-			Nz::Time m_accumulator;
+			std::shared_ptr<Nz::State> m_previousState;
 			Nz::BoxLayout* m_layout;
-			Nz::SimpleLabelWidget* m_logo;
-			Nz::SimpleLabelWidget* m_logoBackground;
-			Nz::ButtonWidget* m_playButton;
-			Nz::ButtonWidget* m_quitGameButton;
+			Nz::ButtonWidget* m_connectButton;
+			Nz::TextAreaWidget* m_serverAddressArea;
+			Nz::TextAreaWidget* m_loginArea;
 			bool m_autoConnect;
 	};
 }
 
-#include <Game/States/MenuState.inl>
+#include <Game/States/DirectConnectionState.inl>
 
-#endif // TSOM_GAME_STATES_MENUSTATE_HPP
+#endif // TSOM_GAME_STATES_DIRECTCONNECTSTATE_HPP

--- a/src/Game/States/DirectConnectionState.inl
+++ b/src/Game/States/DirectConnectionState.inl
@@ -1,0 +1,7 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+namespace tsom
+{
+}

--- a/src/Game/States/MenuState.cpp
+++ b/src/Game/States/MenuState.cpp
@@ -44,7 +44,6 @@ namespace tsom
 			textDrawer.SetTextFont(filesystem.Open<Nz::Font>("assets/fonts/axaxax bd.otf"));
 			textDrawer.SetTextStyle(Nz::TextStyle::OutlineOnly);
 		});
-		m_logo->Resize(m_logo->GetPreferredSize());
 
 		m_logoBackground = m_logo->Add<Nz::SimpleLabelWidget>();
 		m_logoBackground->UpdateDrawer([&](Nz::SimpleTextDrawer& textDrawer)
@@ -56,7 +55,6 @@ namespace tsom
 			textDrawer.SetTextFont(filesystem.Open<Nz::Font>("assets/fonts/axaxax bd.otf"));
 			textDrawer.SetTextStyle(Nz::TextStyle::OutlineOnly);
 		});
-		m_logoBackground->Resize(m_logoBackground->GetPreferredSize());
 		m_logoBackground->SetPosition({ 7.f, -7.f });
 
 		m_layout = CreateWidget<Nz::BoxLayout>(Nz::BoxLayoutOrientation::TopToBottom);
@@ -99,14 +97,12 @@ namespace tsom
 		{
 			textDrawer.SetCharacterSpacingOffset(std::sin(m_accumulator.AsSeconds() * 0.2f) * 5.f);
 		});
-		m_logo->Resize(m_logo->GetPreferredSize());
 		m_logo->CenterHorizontal();
 
 		m_logoBackground->UpdateDrawer([&](Nz::SimpleTextDrawer& textDrawer)
 		{
 			textDrawer.SetCharacterSpacingOffset(std::sin(m_accumulator.AsSeconds() * 0.2f) * 5.f);
 		});
-		m_logoBackground->Resize(m_logoBackground->GetPreferredSize());
 
 		return true;
 	}

--- a/src/Game/States/PlayState.cpp
+++ b/src/Game/States/PlayState.cpp
@@ -152,8 +152,8 @@ namespace tsom
 
 				nlohmann::json responseDoc = nlohmann::json::parse(result.GetBody());
 
-				std::string_view playerGuid = responseDoc["guid"];
-				std::string_view playerNickname = responseDoc["nickname"];
+				std::string playerGuid = responseDoc["guid"];
+				std::string playerNickname = responseDoc["nickname"];
 
 				m_directConnect->UpdateText(Nz::SimpleTextDrawer::Draw(fmt::format("Play as {}", playerNickname), 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
 				m_directConnect->Enable();

--- a/src/Game/States/PlayState.cpp
+++ b/src/Game/States/PlayState.cpp
@@ -126,7 +126,7 @@ namespace tsom
 		webService.QueueRequest([&](Nz::WebRequest& request)
 		{
 			request.SetupPost();
-			request.SetURL(fmt::format("{}/v1/player/authenticate", gameConfig.GetStringValue("Api.Url"), BuildConfig));
+			request.SetURL(fmt::format("{}/v1/player/auth", gameConfig.GetStringValue("Api.Url"), BuildConfig));
 			request.SetServiceName("TSOM Player Info");
 
 			nlohmann::json connectBody;
@@ -200,7 +200,7 @@ namespace tsom
 			webService.QueueRequest([&](Nz::WebRequest& request)
 			{
 				request.SetupPost();
-				request.SetURL(fmt::format("{}/v1/player/test", gameConfig.GetStringValue("Api.Url"), BuildConfig));
+				request.SetURL(fmt::format("{}/v1/game/connect", gameConfig.GetStringValue("Api.Url"), BuildConfig));
 				request.SetServiceName("TSOM Player Info");
 
 				nlohmann::json connectBody;
@@ -255,7 +255,7 @@ namespace tsom
 							Packets::AuthRequest::AuthenticatedPlayerData playerData;
 							playerData.connectionToken = std::move(token);
 
-							stateData.connectionState->Connect(serverAddress, std::move(playerData), std::move(playState));
+							stateData.connectionState->Connect(serverAddress, std::move(playerData), playState);
 						}
 					}
 					catch (const std::exception& e)

--- a/src/Game/States/PlayState.cpp
+++ b/src/Game/States/PlayState.cpp
@@ -1,0 +1,187 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#include <Game/States/PlayState.hpp>
+#include <CommonLib/GameConstants.hpp>
+#include <CommonLib/InternalConstants.hpp>
+#include <CommonLib/UpdaterAppComponent.hpp>
+#include <CommonLib/Version.hpp>
+#include <Game/GameConfigAppComponent.hpp>
+#include <Game/States/ConnectionState.hpp>
+#include <Game/States/CreatePlayerState.hpp>
+#include <Game/States/DirectConnectionState.hpp>
+#include <Game/States/GameState.hpp>
+#include <Game/States/UpdateState.hpp>
+#include <Nazara/Core/ApplicationBase.hpp>
+#include <Nazara/Core/StateMachine.hpp>
+#include <Nazara/Core/StringExt.hpp>
+#include <Nazara/Network/Algorithm.hpp>
+#include <Nazara/Network/IpAddress.hpp>
+#include <Nazara/Network/Network.hpp>
+#include <Nazara/Network/WebServiceAppComponent.hpp>
+#include <Nazara/TextRenderer/SimpleTextDrawer.hpp>
+#include <Nazara/Widgets/BoxLayout.hpp>
+#include <Nazara/Widgets/ButtonWidget.hpp>
+#include <fmt/color.h>
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+#include <optional>
+
+namespace tsom
+{
+	PlayState::PlayState(std::shared_ptr<StateData> stateData, std::shared_ptr<Nz::State> previousState) :
+	WidgetState(stateData),
+	m_previousState(std::move(previousState))
+	{
+		auto& gameConfig = GetStateData().app->GetComponent<GameConfigAppComponent>().GetConfig();
+
+		std::string_view playerToken = gameConfig.GetStringValue("Player.Token");
+
+		m_layout = CreateWidget<Nz::BoxLayout>(Nz::BoxLayoutOrientation::TopToBottom);
+
+		m_createOrConnectButton = m_layout->Add<Nz::ButtonWidget>();
+		m_createOrConnectButton->UpdateText(Nz::SimpleTextDrawer::Draw("Loading player info...", 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+		m_createOrConnectButton->SetMaximumWidth(m_createOrConnectButton->GetPreferredWidth() * 1.5f);
+		ConnectSignal(m_createOrConnectButton->OnButtonTrigger, [this](const Nz::ButtonWidget*)
+		{
+			OnCreateOrConnectPressed();
+		});
+
+		m_directConnect = m_layout->Add<Nz::ButtonWidget>();
+		m_directConnect->UpdateText(Nz::SimpleTextDrawer::Draw("Direct connection", 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+		m_directConnect->SetMaximumWidth(m_directConnect->GetPreferredWidth() * 1.5f);
+		ConnectSignal(m_directConnect->OnButtonTrigger, [this](const Nz::ButtonWidget*)
+		{
+			m_nextState = std::make_shared<DirectConnectionState>(GetStateDataPtr(), shared_from_this());
+		});
+
+		Nz::ButtonWidget* backButton = m_layout->Add<Nz::ButtonWidget>();
+		backButton->UpdateText(Nz::SimpleTextDrawer::Draw("Back", 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+		backButton->SetMaximumWidth(backButton->GetPreferredWidth() * 1.5f);
+		backButton->OnButtonTrigger.Connect([this](const Nz::ButtonWidget*)
+		{
+			m_nextState = m_previousState;
+		});
+
+		const Nz::CommandLineParameters& cmdParams = GetStateData().app->GetCommandLineParameters();
+		m_autoConnect = cmdParams.HasFlag("auto-connect");
+	}
+
+	void PlayState::Enter(Nz::StateMachine& fsm)
+	{
+		WidgetState::Enter(fsm);
+
+		auto& gameConfig = GetStateData().app->GetComponent<GameConfigAppComponent>().GetConfig();
+
+		std::string_view playerToken = gameConfig.GetStringValue("Player.Token");
+
+		if (!playerToken.empty())
+		{
+			m_createOrConnectButton->UpdateText(Nz::SimpleTextDrawer::Draw("Loading player info...", 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+			m_createOrConnectButton->SetMaximumWidth(m_createOrConnectButton->GetPreferredWidth() * 1.5f);
+			m_createOrConnectButton->Disable();
+		}
+		else
+		{
+			m_createOrConnectButton->UpdateText(Nz::SimpleTextDrawer::Draw("Create new player", 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+			m_createOrConnectButton->SetMaximumWidth(m_createOrConnectButton->GetPreferredWidth() * 1.5f);
+			m_createOrConnectButton->Enable();
+
+			m_directConnect->UpdateText(Nz::SimpleTextDrawer::Draw("Play as guest", 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+			m_directConnect->SetMaximumWidth(m_directConnect->GetPreferredWidth() * 1.5f);
+			m_directConnect->Enable();
+		}
+
+		// First layout happens in WidgetState::Enter and doesn't take m_createPlayerButton state into account
+		LayoutWidgets(GetStateData().canvas->GetSize());
+
+		FetchPlayerInfo();
+	}
+
+	bool PlayState::Update(Nz::StateMachine& fsm, Nz::Time elapsedTime)
+	{
+		if (m_nextState)
+		{
+			fsm.ChangeState(std::move(m_nextState));
+			return true;
+		}
+
+		if (m_autoConnect)
+		{
+			OnCreateOrConnectPressed();
+			m_autoConnect = false;
+		}
+
+		return true;
+	}
+
+	void PlayState::FetchPlayerInfo()
+	{
+		auto& gameConfig = GetStateData().app->GetComponent<GameConfigAppComponent>().GetConfig();
+		auto& webService = GetStateData().app->GetComponent<Nz::WebServiceAppComponent>();
+
+		std::string_view playerToken = gameConfig.GetStringValue("Player.Token");
+
+		webService.QueueRequest([&](Nz::WebRequest& request)
+		{
+			request.SetupPost();
+			request.SetURL(fmt::format("{}/v1/player/authenticate", gameConfig.GetStringValue("Api.Url"), BuildConfig));
+			request.SetServiceName("TSOM Player Info");
+
+			nlohmann::json connectBody;
+			connectBody["token"] = playerToken;
+
+			request.SetJSonContent(connectBody.dump());
+
+			request.SetResultCallback([&](Nz::WebRequestResult&& result)
+			{
+				if (!result.HasSucceeded())
+				{
+					fmt::print(fg(fmt::color::red), "failed to retrieve player info: {}\n", result.GetErrorMessage());
+					m_createOrConnectButton->UpdateText(Nz::SimpleTextDrawer::Draw("failed to connect to server", 24, Nz::TextStyle::Bold, Nz::Color::Red()));
+					return;
+				}
+
+				if (result.GetStatusCode() != 200)
+				{
+					fmt::print(fg(fmt::color::red), "failed to retrieve player info (error {}): {}\n", result.GetStatusCode(), result.GetBody());
+					m_createOrConnectButton->UpdateText(Nz::SimpleTextDrawer::Draw("failed to retrieve player", 24, Nz::TextStyle::Bold, Nz::Color::Red()));
+					return;
+				}
+
+				nlohmann::json responseDoc = nlohmann::json::parse(result.GetBody());
+
+				std::string_view playerGuid = responseDoc["guid"];
+				std::string_view playerNickname = responseDoc["nickname"];
+
+				m_directConnect->UpdateText(Nz::SimpleTextDrawer::Draw(fmt::format("Play as {}", playerNickname), 36, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+				m_directConnect->Enable();
+			});
+
+			return true;
+		});
+	}
+
+	void PlayState::LayoutWidgets(const Nz::Vector2f& newSize)
+	{
+		m_layout->Resize({ newSize.x * 0.2f, m_layout->GetPreferredHeight() });
+		m_layout->Center();
+	}
+
+	void PlayState::OnCreateOrConnectPressed()
+	{
+		auto& gameConfig = GetStateData().app->GetComponent<GameConfigAppComponent>();
+		std::string_view playerToken = gameConfig.GetConfig().GetStringValue("Player.Token");
+
+		if (!playerToken.empty())
+		{
+			// TODO
+		}
+		else
+		{
+			m_nextState = std::make_shared<CreatePlayerState>(GetStateDataPtr(), shared_from_this());
+			return;
+		}
+	}
+}

--- a/src/Game/States/PlayState.hpp
+++ b/src/Game/States/PlayState.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#ifndef TSOM_GAME_STATES_MENUSTATE_HPP
-#define TSOM_GAME_STATES_MENUSTATE_HPP
+#ifndef TSOM_GAME_STATES_PLAYSTATE_HPP
+#define TSOM_GAME_STATES_PLAYSTATE_HPP
 
 #include <CommonLib/UpdateInfo.hpp>
 #include <Game/States/WidgetState.hpp>
@@ -16,36 +16,37 @@ namespace Nz
 	class BoxLayout;
 	class ButtonWidget;
 	class LabelWidget;
-	class SimpleLabelWidget;
+	class TextAreaWidget;
 }
 
 namespace tsom
 {
 	class ConnectionState;
 
-	class MenuState : public WidgetState
+	class PlayState : public WidgetState
 	{
 		public:
-			MenuState(std::shared_ptr<StateData> stateData);
-			~MenuState() = default;
+			PlayState(std::shared_ptr<StateData> stateData, std::shared_ptr<Nz::State> previousState);
+			~PlayState() = default;
 
+			void Enter(Nz::StateMachine& fsm) override;
 			bool Update(Nz::StateMachine& fsm, Nz::Time elapsedTime) override;
 
 		private:
+			void FetchPlayerInfo();
 			void LayoutWidgets(const Nz::Vector2f& newSize) override;
+			void OnCreateOrConnectPressed();
 
 			std::optional<UpdateInfo> m_newVersionInfo;
 			std::shared_ptr<Nz::State> m_nextState;
-			Nz::Time m_accumulator;
+			std::shared_ptr<Nz::State> m_previousState;
 			Nz::BoxLayout* m_layout;
-			Nz::SimpleLabelWidget* m_logo;
-			Nz::SimpleLabelWidget* m_logoBackground;
-			Nz::ButtonWidget* m_playButton;
-			Nz::ButtonWidget* m_quitGameButton;
+			Nz::ButtonWidget* m_createOrConnectButton;
+			Nz::ButtonWidget* m_directConnect;
 			bool m_autoConnect;
 	};
 }
 
-#include <Game/States/MenuState.inl>
+#include <Game/States/PlayState.inl>
 
-#endif // TSOM_GAME_STATES_MENUSTATE_HPP
+#endif // TSOM_GAME_STATES_PLAYSTATE_HPP

--- a/src/Game/States/PlayState.inl
+++ b/src/Game/States/PlayState.inl
@@ -1,0 +1,7 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+namespace tsom
+{
+}

--- a/src/Game/States/UpdateState.cpp
+++ b/src/Game/States/UpdateState.cpp
@@ -45,7 +45,7 @@ namespace tsom
 		m_cancelButton->UpdateText(Nz::SimpleTextDrawer::Draw("Cancel update", 24));
 		m_cancelButton->SetMaximumSize(m_cancelButton->GetPreferredSize());
 
-		m_cancelButton->OnButtonTrigger.Connect([this](const Nz::ButtonWidget*)
+		ConnectSignal(m_cancelButton->OnButtonTrigger, [this](const Nz::ButtonWidget*)
 		{
 			GetStateData().app->GetComponent<UpdaterAppComponent>().CancelUpdate();
 			m_isCancelled = true;

--- a/src/Game/States/VersionCheckState.cpp
+++ b/src/Game/States/VersionCheckState.cpp
@@ -1,0 +1,119 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+#include <Game/States/VersionCheckState.hpp>
+#include <CommonLib/InternalConstants.hpp>
+#include <CommonLib/UpdaterAppComponent.hpp>
+#include <CommonLib/Version.hpp>
+#include <Game/States/UpdateState.hpp>
+#include <Nazara/Core/ApplicationBase.hpp>
+#include <Nazara/Core/StateMachine.hpp>
+#include <Nazara/Core/StringExt.hpp>
+#include <Nazara/Network/Algorithm.hpp>
+#include <Nazara/Network/IpAddress.hpp>
+#include <Nazara/Network/Network.hpp>
+#include <Nazara/Network/WebServiceAppComponent.hpp>
+#include <Nazara/TextRenderer/SimpleTextDrawer.hpp>
+#include <Nazara/Widgets/BoxLayout.hpp>
+#include <Nazara/Widgets/ButtonWidget.hpp>
+#include <Nazara/Widgets/LabelWidget.hpp>
+#include <fmt/color.h>
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+namespace tsom
+{
+	VersionCheckState::VersionCheckState(std::shared_ptr<StateData> stateData) :
+	WidgetState(stateData)
+	{
+		m_updateLayout = CreateWidget<Nz::BoxLayout>(Nz::BoxLayoutOrientation::TopToBottom);
+
+		m_updateLabel = m_updateLayout->Add<Nz::LabelWidget>();
+		m_updateLabel->UpdateText(Nz::SimpleTextDrawer::Draw("A new version is available!", 18));
+
+		m_updateButton = m_updateLayout->Add<Nz::ButtonWidget>();
+		m_updateButton->UpdateText(Nz::SimpleTextDrawer::Draw("Update game", 18, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+		m_updateButton->SetMaximumWidth(m_updateButton->GetPreferredWidth());
+		m_updateButton->OnButtonTrigger.Connect([this](const Nz::ButtonWidget*)
+		{
+			OnUpdatePressed();
+		});
+	}
+
+	void VersionCheckState::Enter(Nz::StateMachine& fsm)
+	{
+		WidgetState::Enter(fsm);
+
+		CheckVersion();
+	}
+
+	bool VersionCheckState::Update(Nz::StateMachine& fsm, Nz::Time elapsedTime)
+	{
+		if (m_nextState)
+		{
+			fsm.PopStatesUntil(shared_from_this());
+			fsm.ChangeState(std::move(m_nextState));
+			return true;
+		}
+
+		return true;
+	}
+
+	void VersionCheckState::CheckVersion()
+	{
+		m_updateLayout->Hide();
+		m_newVersionInfo.reset();
+
+		auto* updater = GetStateData().app->TryGetComponent<UpdaterAppComponent>();
+		if (!updater)
+			return;
+
+		updater->FetchLastVersion([state = std::static_pointer_cast<VersionCheckState>(shared_from_this())](Nz::Result<UpdateInfo, std::string>&& result)
+		{
+			if (!result)
+			{
+				fmt::print(fg(fmt::color::red), "failed to get version update: {}\n", result.GetError());
+				return;
+			}
+
+			state->OnUpdateInfoReceived(std::move(result).GetValue());
+		});
+	}
+
+	void VersionCheckState::LayoutWidgets(const Nz::Vector2f& newSize)
+	{
+		m_updateLayout->Resize({ std::max(m_updateLabel->GetPreferredWidth(), m_updateButton->GetPreferredWidth()), m_updateLabel->GetPreferredHeight() * 2.f + m_updateButton->GetPreferredHeight() });
+		m_updateLayout->SetPosition(newSize * Nz::Vector2f(0.9f, 0.1f) - m_updateButton->GetSize() * 0.5f);
+	}
+
+	void VersionCheckState::OnUpdateInfoReceived(UpdateInfo&& updateInfo)
+	{
+		semver::version currentGameVersion(GameMajorVersion, GameMinorVersion, GamePatchVersion);
+
+		if (updateInfo.assetVersion > currentGameVersion || updateInfo.binaryVersion > currentGameVersion)
+		{
+			m_newVersionInfo = std::move(updateInfo);
+			fmt::print(fg(fmt::color::yellow), "new version available: {}\n", m_newVersionInfo->binaryVersion.to_string());
+
+			// We're not supposed to be able to have asset-only version but let's prepare for this
+			semver::version biggestVer = std::max(m_newVersionInfo->assetVersion, m_newVersionInfo->binaryVersion);
+
+			m_updateButton->UpdateText(Nz::SimpleTextDrawer::Draw("Update game to " + biggestVer.to_string(), 18, Nz::TextStyle_Regular, Nz::Color::sRGBToLinear(Nz::Color(0.13f))));
+			m_updateButton->SetMaximumWidth(m_updateButton->GetPreferredWidth());
+
+			m_updateLayout->Show();
+		}
+		else
+			fmt::print("no new version available\n");
+	}
+
+	void VersionCheckState::OnUpdatePressed()
+	{
+		if (!m_newVersionInfo)
+			return;
+
+		m_nextState = std::make_shared<UpdateState>(GetStateDataPtr(), shared_from_this(), std::move(*m_newVersionInfo));
+		m_newVersionInfo.reset();
+	}
+}

--- a/src/Game/States/VersionCheckState.hpp
+++ b/src/Game/States/VersionCheckState.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#ifndef TSOM_GAME_STATES_MENUSTATE_HPP
-#define TSOM_GAME_STATES_MENUSTATE_HPP
+#ifndef TSOM_GAME_STATES_VERSIONCHECKSTATE_HPP
+#define TSOM_GAME_STATES_VERSIONCHECKSTATE_HPP
 
 #include <CommonLib/UpdateInfo.hpp>
 #include <Game/States/WidgetState.hpp>
@@ -16,36 +16,35 @@ namespace Nz
 	class BoxLayout;
 	class ButtonWidget;
 	class LabelWidget;
-	class SimpleLabelWidget;
 }
 
 namespace tsom
 {
 	class ConnectionState;
 
-	class MenuState : public WidgetState
+	class VersionCheckState : public WidgetState
 	{
 		public:
-			MenuState(std::shared_ptr<StateData> stateData);
-			~MenuState() = default;
+			VersionCheckState(std::shared_ptr<StateData> stateData);
+			~VersionCheckState() = default;
 
+			void Enter(Nz::StateMachine& fsm) override;
 			bool Update(Nz::StateMachine& fsm, Nz::Time elapsedTime) override;
 
 		private:
+			void CheckVersion();
 			void LayoutWidgets(const Nz::Vector2f& newSize) override;
+			void OnUpdateInfoReceived(UpdateInfo&& updateInfo);
+			void OnUpdatePressed();
 
 			std::optional<UpdateInfo> m_newVersionInfo;
 			std::shared_ptr<Nz::State> m_nextState;
-			Nz::Time m_accumulator;
-			Nz::BoxLayout* m_layout;
-			Nz::SimpleLabelWidget* m_logo;
-			Nz::SimpleLabelWidget* m_logoBackground;
-			Nz::ButtonWidget* m_playButton;
-			Nz::ButtonWidget* m_quitGameButton;
-			bool m_autoConnect;
+			Nz::BoxLayout* m_updateLayout;
+			Nz::ButtonWidget* m_updateButton;
+			Nz::LabelWidget* m_updateLabel;
 	};
 }
 
-#include <Game/States/MenuState.inl>
+#include <Game/States/VersionCheckState.inl>
 
-#endif // TSOM_GAME_STATES_MENUSTATE_HPP
+#endif // TSOM_GAME_STATES_VERSIONCHECKSTATE_HPP

--- a/src/Game/States/VersionCheckState.inl
+++ b/src/Game/States/VersionCheckState.inl
@@ -1,0 +1,7 @@
+// Copyright (C) 2024 Jérôme "SirLynix" Leclercq (lynix680@gmail.com) (lynix680@gmail.com)
+// This file is part of the "This Space Of Mine" project
+// For conditions of distribution and use, see copyright notice in LICENSE
+
+namespace tsom
+{
+}

--- a/src/Game/States/WidgetState.inl
+++ b/src/Game/States/WidgetState.inl
@@ -10,7 +10,10 @@ namespace tsom
 	template<typename T, typename ...Args>
 	void WidgetState::ConnectSignal(T& signal, Args&&... args)
 	{
-		m_cleanupFunctions.emplace_back([connection = signal.Connect(std::forward<Args>(args)...)]() mutable { connection.Disconnect(); });
+		m_cleanupFunctions.emplace_back([connection = signal.Connect(std::forward<Args>(args)...)]() mutable
+		{
+			connection.Disconnect();
+		});
 	}
 
 	template<typename T, typename... Args>

--- a/src/Game/main.cpp
+++ b/src/Game/main.cpp
@@ -38,19 +38,19 @@ int GameMain(int argc, char* argv[])
 	app.AddComponent<Nz::TaskSchedulerAppComponent>();
 	app.AddComponent<Nz::WindowingAppComponent>();
 
+	// Game setup
+	auto& gameConfig = app.AddComponent<tsom::GameConfigAppComponent>();
+	app.AddComponent<tsom::GameAppComponent>();
+
 	try
 	{
 		app.AddComponent<Nz::WebServiceAppComponent>();
-		app.AddComponent<tsom::UpdaterAppComponent>();
+		app.AddComponent<tsom::UpdaterAppComponent>(gameConfig.GetConfig());
 	}
 	catch (const std::exception& e)
 	{
 		fmt::print(fg(fmt::color::red), "failed to enable web services (automatic updating will be disabled): {0}!\n", e.what());
 	}
-
-	// Game setup
-	app.AddComponent<tsom::GameConfigAppComponent>();
-	app.AddComponent<tsom::GameAppComponent>();
 
 	return app.Run();
 }

--- a/src/Server/ServerConfigAppComponent.cpp
+++ b/src/Server/ServerConfigAppComponent.cpp
@@ -4,6 +4,7 @@
 
 #include <Server/ServerConfigAppComponent.hpp>
 #include <NazaraUtils/PathUtils.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
 #include <fmt/color.h>
 #include <fmt/format.h>
 
@@ -12,17 +13,46 @@ namespace tsom
 	ServerConfigFile::ServerConfigFile()
 	{
 		RegisterStringOption("Api.Url");
+		RegisterStringOption("ConnectionToken.EncryptionKey", "");
 		RegisterIntegerOption("Server.Port", 1, 0xFFFF, 29536);
 		RegisterBoolOption("Server.SleepWhenEmpty", true);
 		RegisterStringOption("Save.Directory", "saves/chunks");
 		RegisterIntegerOption("Save.Interval", 0, 60 * 60, 30);
 	}
 
+	void ServerConfigFile::PostLoad()
+	{
+		using base64 = cppcodec::base64_rfc4648;
+
+		std::vector<std::uint8_t> connectionTokenEncryptionKey = base64::decode(GetStringValue("ConnectionToken.EncryptionKey"));
+		if (!connectionTokenEncryptionKey.empty())
+		{
+			if (connectionTokenEncryptionKey.size() != m_connectionTokenEncryptionKey.size())
+				throw std::runtime_error(fmt::format("connection token encryption key has incorrect length (expected 32bytes, got {0})", connectionTokenEncryptionKey.size()));
+
+			std::memcpy(&m_connectionTokenEncryptionKey[0], &connectionTokenEncryptionKey[0], m_connectionTokenEncryptionKey.size());
+		}
+	}
+
+
 	ServerConfigAppComponent::ServerConfigAppComponent(Nz::ApplicationBase& app) :
 	ApplicationComponent(app)
 	{
 		if (!m_configFile.LoadFromFile(Nz::Utf8Path("serverconfig.lua")))
+		{
 			fmt::print(fg(fmt::color::red), "failed to load server config\n");
+			return;
+		}
+
+		try
+		{
+			m_configFile.PostLoad();
+		}
+		catch (const std::exception& e)
+		{
+			fmt::print(fg(fmt::color::red), "failed to load server config: {0}\n", e.what());
+			return;
+		}
 	}
 
 	void ServerConfigAppComponent::Save()

--- a/src/Server/ServerConfigAppComponent.cpp
+++ b/src/Server/ServerConfigAppComponent.cpp
@@ -11,6 +11,7 @@ namespace tsom
 {
 	ServerConfigFile::ServerConfigFile()
 	{
+		RegisterStringOption("Api.Url");
 		RegisterIntegerOption("Server.Port", 1, 0xFFFF, 29536);
 		RegisterBoolOption("Server.SleepWhenEmpty", true);
 		RegisterStringOption("Save.Directory", "saves/chunks");

--- a/src/Server/ServerConfigAppComponent.hpp
+++ b/src/Server/ServerConfigAppComponent.hpp
@@ -9,14 +9,23 @@
 
 #include <CommonLib/ConfigFile.hpp>
 #include <Nazara/Core/ApplicationComponent.hpp>
-#include <NazaraUtils/Prerequisites.hpp>
+#include <array>
 
 namespace tsom
 {
 	class ServerConfigFile : public ConfigFile
 	{
+		friend class ServerConfigAppComponent;
+
 		public:
 			ServerConfigFile();
+
+			inline const std::array<Nz::UInt8, 32>& GetConnectionTokenEncryptionKey() const;
+
+		private:
+			void PostLoad();
+
+			std::array<Nz::UInt8, 32> m_connectionTokenEncryptionKey;
 	};
 
 	class ServerConfigAppComponent final : public Nz::ApplicationComponent

--- a/src/Server/ServerConfigAppComponent.inl
+++ b/src/Server/ServerConfigAppComponent.inl
@@ -4,6 +4,11 @@
 
 namespace tsom
 {
+	inline const std::array<Nz::UInt8, 32>& ServerConfigFile::GetConnectionTokenEncryptionKey() const
+	{
+		return m_connectionTokenEncryptionKey;
+	}
+
 	inline ServerConfigFile& ServerConfigAppComponent::GetConfig()
 	{
 		return m_configFile;

--- a/src/Server/main.cpp
+++ b/src/Server/main.cpp
@@ -33,6 +33,7 @@ int ServerMain(int argc, char* argv[])
 	instanceConfig.pauseWhenEmpty = config.GetBoolValue("Server.SleepWhenEmpty");
 	instanceConfig.saveDirectory = Nz::Utf8Path(config.GetStringValue("Save.Directory"));
 	instanceConfig.saveInterval = Nz::Time::Seconds(config.GetIntegerValue<long long>("Save.Interval"));
+	instanceConfig.connectionTokenEncryptionKey = config.GetConnectionTokenEncryptionKey();
 
 	auto& instance = worldAppComponent.AddInstance(std::move(instanceConfig));
 	auto& sessionManager = instance.AddSessionManager(serverPort);

--- a/src/ServerLib/ServerInstance.cpp
+++ b/src/ServerLib/ServerInstance.cpp
@@ -23,12 +23,13 @@ namespace tsom
 	constexpr unsigned int chunkSaveVersion = 1;
 
 	ServerInstance::ServerInstance(Nz::ApplicationBase& application, Config config) :
-	m_tickIndex(0),
+	m_connectionTokenEncryptionKey(config.connectionTokenEncryptionKey),
 	m_saveDirectory(std::move(config.saveDirectory)),
 	m_players(256),
 	m_tickAccumulator(Nz::Time::Zero()),
 	m_tickDuration(Constants::TickDuration),
 	m_saveInterval(config.saveInterval),
+	m_tickIndex(0),
 	m_application(application),
 	m_pauseWhenEmpty(config.pauseWhenEmpty)
 	{

--- a/src/ServerLib/Session/InitialSessionHandler.cpp
+++ b/src/ServerLib/Session/InitialSessionHandler.cpp
@@ -46,7 +46,7 @@ namespace tsom
 		{
 			[&](Packets::AuthRequest::AnonymousPlayerData& anonymousData) -> bool
 			{
-				login = std::move(anonymousData.nickname);
+				login = std::move(anonymousData.nickname).Str();
 
 				fmt::print("{0} authenticated\n", login);
 				return true;

--- a/src/ServerLib/Session/InitialSessionHandler.cpp
+++ b/src/ServerLib/Session/InitialSessionHandler.cpp
@@ -48,7 +48,7 @@ namespace tsom
 			{
 				login = std::move(anonymousData.nickname).Str();
 
-				fmt::print("{0} authenticated\n", login);
+				fmt::print("{0} authenticated (anonymous)\n", login);
 				return true;
 			},
 			[&](Packets::AuthRequest::AuthenticatedPlayerData& authenticatedData) -> bool
@@ -59,12 +59,13 @@ namespace tsom
 				ConnectionTokenAuth errorCode = ConnectionTokenPrivate::AuthAndDecrypt(authenticatedData.connectionToken, key, &tokenPrivate);
 				if (errorCode != ConnectionTokenAuth::Success)
 				{
-					fmt::print(fg(fmt::color::red), "{0} token is invalid\n", login);
-					FailAuth(AuthError::ProtocolError);
+					fmt::print(fg(fmt::color::red), "connection token is invalid\n", login);
+					FailAuth(AuthError::InvalidToken);
 					return false;
 				}
 
 				login = std::move(tokenPrivate.player.nickname);
+				fmt::print("{0} authenticated\n", login);
 				return true;
 			}
 		}, authRequest.token);

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,6 +12,7 @@ add_requires("fmt", { configs = { header_only = false }})
 add_requires("libcurl", { configs = { shared = true }, system = false })
 add_requires(
 	"concurrentqueue",
+	"libsodium",
 	"lz4",
 	"hopscotch-map",
 	"nlohmann_json",
@@ -76,7 +77,7 @@ target("CommonLib", function ()
 
 	add_packages("nazaraengine", { components = { "physics3d", "network" }, public = true })
 	add_packages("concurrentqueue", "semver", "fmt", "hopscotch-map", "nlohmann_json", "sol2", { public = true })
-	add_packages("lz4", "perlinnoise")
+	add_packages("libsodium", "lz4", "perlinnoise")
 
 	if is_plat("windows") then
 		add_packages("stackwalker")

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,6 +12,7 @@ add_requires("fmt", { configs = { header_only = false }})
 add_requires("libcurl", { configs = { shared = true }, system = false })
 add_requires(
 	"concurrentqueue",
+	"cppcodec",
 	"libsodium",
 	"lz4",
 	"hopscotch-map",
@@ -76,7 +77,7 @@ target("CommonLib", function ()
 	add_options("commonlib_static")
 
 	add_packages("nazaraengine", { components = { "physics3d", "network" }, public = true })
-	add_packages("concurrentqueue", "semver", "fmt", "hopscotch-map", "nlohmann_json", "sol2", { public = true })
+	add_packages("concurrentqueue", "cppcodec", "semver", "fmt", "hopscotch-map", "nlohmann_json", "sol2", { public = true })
 	add_packages("libsodium", "lz4", "perlinnoise")
 
 	if is_plat("windows") then


### PR DESCRIPTION
Implement player authentication using [This API Of Mine](https://github.com/DigitalPulseSoftware/ThisAPIOfMine) (branch players).

The game client can create a player using a nickname and it gets a player token from the API.

This player token is stored in the game config file and allows the game to authenticate its player and connect to the game server.

When connecting to the game server, the client asks the API for a connection token which gives the client the following infos:
- game server address/port
- encryption keys (not used yet but will allow for encryption between the client and server)
- private token data.

It sends those to the game server which shares an encryption key with the API, allowing it to authenticate and decrypt the private token part, containing the following info:
- player data (uuid and nickname for now)
- an API url and token, allowing the game server to communicate in a secure way with the API to retrive/modify the player data at will