### PR TITLE
Fix compilation on macOS by replacing sol::nil with sol::lua_nil

### DIFF
--- a/src/CommonLib/ChunkGenerator.cpp
+++ b/src/CommonLib/ChunkGenerator.cpp
@@ -27,7 +27,7 @@ namespace tsom
 
 	ChunkGenerator::~ChunkGenerator()
 	{
-		m_generationFunction = sol::nil;
+		m_generationFunction = sol::lua_nil;
 	}
 
 	Nz::Result<std::vector<BlockIndex>, std::string> ChunkGenerator::Generate(Chunk& chunk, const Nz::Vector3ui& chunkCount, const std::unordered_map<std::string, EntityProperty>& properties) const

--- a/src/CommonLib/Scripting/SharedScriptingLibrary.cpp
+++ b/src/CommonLib/Scripting/SharedScriptingLibrary.cpp
@@ -53,7 +53,7 @@ namespace tsom
 			{
 				sol::state_view state(L);
 
-				sol::object retVal = sol::nil;
+				sol::object retVal = sol::lua_nil;
 				auto callback = [&](const Nz::Physics3DSystem::RaycastHit& hitInfo)
 				{
 					ScriptedEntityComponent* scriptedEntity = nullptr;


### PR DESCRIPTION
nil is a keyword in objective C/C++ which conflict with sol::nil