### PR TITLE
[CI/CD] Automatically deploy TSOM to itch.io along with the current GitHub releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -162,3 +162,48 @@ jobs:
         asset_name: ${{ env.OUTPUT_FILE }}.sha256
         tag: ${{ github.ref }}
         overwrite: true
+
+  itch_publish_job:
+    needs: [build]
+    if: ${{ startsWith(github.event.ref, 'refs/tags/')}}
+
+    runs-on: ubuntu-latest
+
+    env:
+      BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+
+    steps:
+      - name: Install butler
+        run: |
+          curl -L -o butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default
+          unzip butler.zip
+
+          chmod +x butler
+
+          ./butler -V
+
+      - name: Download Artifacts
+        uses: robinraju/release-downloader@v1
+        with:
+          tag: ${{ github.ref }}
+          fileName: '*.tgz'
+          out-file-path: downloads-tgz
+
+      - name: Download Artifacts
+        uses: robinraju/release-downloader@v1
+        with:
+          tag: ${{ github.ref }}
+          fileName: '*.zip'
+          out-file-path: downloads-zip
+
+      - name: Upload build
+        run: |
+          for file in downloads-tgz/*; do
+            filename=$(basename -- "$file")
+            ./butler push "$file" lynix/this-space-of-mine:"${filename%.*}"
+          done
+          for file in downloads-zip/*; do
+            filename=$(basename -- "$file")
+            ./butler push "$file" lynix/this-space-of-mine:"${filename%.*}"
+          done
+


### PR DESCRIPTION
This PR changes the github action workflow in order to eventuall upload the game binaries to itch.io.

We're using [butler](https://itch.io/docs/butler/) for this purpose. A tool made by itch to automatically upload builds.
The CI will upload the binaries to https://lynix.itch.io/this-space-of-mine, and if the page is public, the build will automatically be public too.

In order to work, this is using an API Key generated on itch.io website. You should create an organization or repository secret named  "BUTLER_API_KEY". To get its value, you can take a look at the [official documentation](https://itch.io/docs/butler/login.html#running-butler-from-ci-builds-github-actions-gitlab-ci-etc)

You also have to manually create the project on itch before (without uploading any files).

I'd also recommend, once the web version works again, to build it and automatically upload it to itch.io. You just need to use `./butler push FOLDER lynix/this-space-of-mine:CHANNEL` to upload files where folder is the whole folder you want to push to itch, and CHANNEL is the name of the achive on itch side.